### PR TITLE
fix: update interaction caching to use message ID instead of interaction ID

### DIFF
--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -120,14 +120,14 @@ export abstract class Cache {
     return this.processCache.get(messageId);
   }
 
-  private static getInteractionKey = (userId: string, interactionId: string): string => `${userId}%${interactionId}`;
+  private static getInteractionKey = (userId: string, msgId: string): string => `${userId}%${msgId}`;
 
-  static saveInteraction(userId: string, interactionId: string, newCache: InteractionCache) {
-    const key = this.getInteractionKey(userId, interactionId);
+  static saveInteraction(userId: string, msgId: string, newCache: InteractionCache) {
+    const key = this.getInteractionKey(userId, msgId);
     this.interactionCache.set(key, newCache);
   }
 
-  static getInteraction(userId: string, interactionId: string): InteractionCache | undefined {
-    return this.interactionCache.get(this.getInteractionKey(userId, interactionId));
+  static getInteraction(userId: string, msgId: string): InteractionCache | undefined {
+    return this.interactionCache.get(this.getInteractionKey(userId, msgId));
   }
 }

--- a/src/commands/Setup.ts
+++ b/src/commands/Setup.ts
@@ -39,6 +39,6 @@ export class SetupCommand extends Command {
       ephemeral: true,
     });
     const msg = await imsg.fetch();
-    Cache.saveInteraction(interaction.user.id, interaction.id, new InteractionCache(msg, interaction));
+    Cache.saveInteraction(interaction.user.id, msg.id, new InteractionCache(msg, interaction));
   }
 }

--- a/src/interaction-handlers/ButtonInteractions.ts
+++ b/src/interaction-handlers/ButtonInteractions.ts
@@ -17,7 +17,7 @@ export class ButtonInteractions extends InteractionHandler {
 
   public async run(interaction: ButtonInteraction) {
     const pCache = Cache.getProcess(interaction.message.id);
-    const iCache = Cache.getInteraction(interaction.user.id, interaction.id);
+    const iCache = Cache.getInteraction(interaction.user.id, interaction.message.id);
 
     if (interaction.customId == LogSendToUser) {
       if (!pCache) {


### PR DESCRIPTION
- Update `getInteractionKey` to use message ID instead of interaction ID
- Update `saveInteraction` and `getInteraction` methods to use message ID instead of interaction ID
- Update references to interaction ID in `ButtonInteractions` and `SetupCommand` to use message ID