### PR TITLE
fix: move version comparison logic to PluginValidation class

### DIFF
--- a/src/Functions/Processors/RPH/RPHValidator.ts
+++ b/src/Functions/Processors/RPH/RPHValidator.ts
@@ -4,6 +4,7 @@ import { PluginType } from '../../../CustomTypes/Enums/PluginType';
 import { State } from '../../../CustomTypes/Enums/State';
 import { RPHLog } from '../../../CustomTypes/LogTypes/RPHLog';
 import { Plugin } from '../../../CustomTypes/MainTypes/Plugin';
+import { PluginValidation } from '../../Validations/Plugins';
 import { RPHAdvancedErrors } from './RPHAdvancedErrors';
 
 export class RPHValidator {
@@ -56,7 +57,7 @@ export class RPHValidator {
             break;
           }
           if (!logPlug.version || !cachePlug.version) continue;
-          const result = this.compareVer(logPlug.version, cachePlug.version);
+          const result = PluginValidation.compareVer(logPlug.version, cachePlug.version);
           if (result < 0) {
             logPlug.eaVersion = cachePlug.version;
             if (!log.outdated.some((x) => x.name === logPlug.name)) {
@@ -108,18 +109,5 @@ export class RPHValidator {
     log.validaterCompletedAt = new Date();
     log.elapsedTime = (new Date().getTime() - log.validaterStartedAt.getTime()).toString();
     return log;
-  }
-
-  private static compareVer(version1: string, version2: string): number {
-    const parts1 = version1.split('.').map(Number);
-    const parts2 = version2.split('.').map(Number);
-    const length = Math.max(parts1.length, parts2.length);
-    for (let i = 0; i < length; i++) {
-      const num1 = parts1[i] || 0;
-      const num2 = parts2[i] || 0;
-      if (num1 < num2) return -1;
-      if (num1 > num2) return 1;
-    }
-    return 0;
   }
 }

--- a/src/Functions/Validations/Plugins.ts
+++ b/src/Functions/Validations/Plugins.ts
@@ -38,6 +38,7 @@ export class PluginValidation {
         `> **Type:** \`${plug.type}\` | **State:** \`${plug.state}\`\r\n` +
         `> **EA Version?:** \`${Boolean(plug.eaVersion && plug.eaVersion !== '0')}\`\r\n`;
 
+      if (this.compareVer(plug.version, webPlug.file_version) === 1) return;
       plug.version = webPlug.file_version;
       await DBManager.editPlugin(plug);
       cnt++;
@@ -81,5 +82,18 @@ export class PluginValidation {
       }
     }
     return allPlugins;
+  }
+
+  public static compareVer(version1: string, version2: string): number {
+    const parts1 = version1.split('.').map(Number);
+    const parts2 = version2.split('.').map(Number);
+    const length = Math.max(parts1.length, parts2.length);
+    for (let i = 0; i < length; i++) {
+      const num1 = parts1[i] || 0;
+      const num2 = parts2[i] || 0;
+      if (num1 < num2) return -1;
+      if (num1 > num2) return 1;
+    }
+    return 0;
   }
 }


### PR DESCRIPTION
- Moved the `compareVer` method from `RPHValidator` to the `PluginValidation` class
- Updated the usage of `compareVer` in `RPHValidator` to use the new static method
- Added a check in `PluginValidation.updatePluginVersion` to skip updating the plugin version if the new version is lower than the current version