### PR TITLE
fix: handle null plugin name in RPHValidator

### DIFF
--- a/src/Functions/Processors/RPH/RPHProcessor.ts
+++ b/src/Functions/Processors/RPH/RPHProcessor.ts
@@ -111,7 +111,12 @@ export class RPHProcessor {
   public async SendReply(interaction: MessageContextMenuCommandInteraction | Message | StringSelectMenuInteraction) {
     this.cache = Cache.getProcess(this.msgId)!;
     if (!this.pluginInfoSent) {
-      await Logger.PluginInfo(this.log.missing, this.log.newVersion, this.log.downloadLink!, await interaction.channel?.messages.fetch(this.msgId)!);
+      await Logger.PluginInfo(
+        this.log.missing,
+        this.log.newVersion,
+        this.log.downloadLink!,
+        await interaction.channel?.messages.fetch(this.cache.OriginalMessage.id)!
+      );
       this.pluginInfoSent = true;
     }
     const comps = new ActionRowBuilder<ButtonBuilder>();

--- a/src/Functions/Processors/RPH/RPHValidator.ts
+++ b/src/Functions/Processors/RPH/RPHValidator.ts
@@ -29,7 +29,7 @@ export class RPHValidator {
       /(?:(?<!CalloutManager\.cs:line 738)\n.+LSPD First Response: (?!無法載入檔案或組件|\[|Creating| |Error)\W?(.{1,40}), Version=(.+), Culture=\w{1,10}, PublicKeyToken=\w{1,10})|(?:Loading plugin .+\wlugins(?:\\|\/)(.+).dll.*)/gm
     );
     for (const match of allMatch) {
-      if (match[1]!.length > 0) {
+      if (match[1] && match[1].length > 0) {
         const plug = Cache.getPlugin(match[1]!);
         if (plug) {
           const newPlug = plug.clone();


### PR DESCRIPTION
- Check if `match[1]` is not null before accessing its length
- Use `this.cache.OriginalMessage.id` instead of `this.msgId` to fetch the original message in RPHProcessor