### PR TITLE
feat: add CORS support and UpdateServer endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@types/express": "^5.0.0",
         "@types/node-cron": "^3.0.11",
         "@types/xml2js": "^0.4.14",
+        "cors": "^2.8.5",
         "date-fns": "^4.1.0",
         "discord.js": "^14.16.3",
         "dotenv": "^16.4.7",
@@ -28,6 +29,7 @@
       "devDependencies": {
         "@eslint/js": "^9.16.0",
         "@prettier/sync": "^0.5.2",
+        "@types/cors": "^2.8.17",
         "@types/node": "^22.10.1",
         "@typescript-eslint/eslint-plugin": "^8.18.0",
         "@typescript-eslint/parser": "^8.18.0",
@@ -1171,6 +1173,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cors": {
+      "version": "2.8.17",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.17.tgz",
+      "integrity": "sha512-8CGDvrBj1zgo2qE+oS3pOCyYNqCPryMWY2bGfwA0dcfopWGgxs+78df0Rs3rc9THP4JkOhLsAa+15VdpAqkcUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
@@ -1962,6 +1974,19 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -4117,6 +4142,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@types/express": "^5.0.0",
     "@types/node-cron": "^3.0.11",
     "@types/xml2js": "^0.4.14",
+    "cors": "^2.8.5",
     "date-fns": "^4.1.0",
     "discord.js": "^14.16.3",
     "dotenv": "^16.4.7",
@@ -33,6 +34,7 @@
   "devDependencies": {
     "@eslint/js": "^9.16.0",
     "@prettier/sync": "^0.5.2",
+    "@types/cors": "^2.8.17",
     "@types/node": "^22.10.1",
     "@typescript-eslint/eslint-plugin": "^8.18.0",
     "@typescript-eslint/parser": "^8.18.0",

--- a/src/Web/APIManager.ts
+++ b/src/Web/APIManager.ts
@@ -1,6 +1,8 @@
 import express from 'express';
+import cors from 'cors';
 import { VersionChecker } from './VersionChecker';
 import { ErrorReport } from './ErrorReport';
+import { UpdateServer } from './SiteConnect/UpdateServer';
 
 export class APIManager {
   private static app = express();
@@ -8,11 +10,14 @@ export class APIManager {
 
   public static init() {
     if (process.env['MAIN_SERVER'] !== '736140566311600138') return;
+    this.app.use(cors());
+    this.app.use(express.json());
     this.setupRoutes();
     this.startServer();
 
     VersionChecker.init();
     ErrorReport.init();
+    UpdateServer.init();
   }
 
   private static setupRoutes() {

--- a/src/Web/SiteConnect/UpdateServer.ts
+++ b/src/Web/SiteConnect/UpdateServer.ts
@@ -1,0 +1,36 @@
+import { Cache } from '../../Cache';
+import { AhChannel } from '../../Functions/AutoHelper/AhChannel';
+import { CaseMonitor } from '../../Functions/AutoHelper/CaseMonitor';
+import { APIManager } from '../APIManager';
+import { Request, Response } from 'express';
+
+export class UpdateServer {
+  public static init() {
+    const app = APIManager.getApp();
+
+    app.post('/SiteConnect/UpdateServer', async (req: Request, res: Response) => {
+      const authToken = req.headers['x-site-auth'];
+
+      if (authToken !== process.env['WEBSITE_KEY']) {
+        res.status(401).json({ error: 'Unauthorized' });
+        return;
+      }
+
+      const { guildId } = req.body;
+
+      if (!guildId) {
+        res.status(400).json({ error: 'Missing guild ID' });
+        return;
+      }
+
+      try {
+        await Cache.resetCache();
+        await AhChannel.UpdateCaseMsg(guildId);
+        await CaseMonitor.Update(guildId);
+        res.status(200).json({ success: true });
+      } catch (error) {
+        res.status(500).json({ error: 'Internal server error' });
+      }
+    });
+  }
+}


### PR DESCRIPTION
- Add `cors` dependency and configure it in `APIManager`
- Implement `UpdateServer` class to handle POST requests to `/SiteConnect/UpdateServer`
- The `UpdateServer` endpoint allows authorized clients to trigger cache reset, case message update, and case monitor update for a specified guild
- Add `@types/cors` dev dependency