### PR TITLE
feat: update setup command and server validation messaging

### DIFF
--- a/src/Functions/Validations/Servers.ts
+++ b/src/Functions/Validations/Servers.ts
@@ -25,15 +25,15 @@ export class ServerValidation {
           '-# This bot is able to read a multitude of different log types and even provide support autonomously!\r\n\r\n' +
           'Created by SuperPyroManiac with the help of Hammer using data collected from ULSS, RPH, and DG.\r\n' +
           'To contribute or for more information, you may visit the PF Discord or GitHub.\r\n\r\n' +
-          'To get started, simply use the /Setup command. This will allow you to configure the bots channels and autohelper.\r\n' +
-          'A web interface is currently in development to replace this, but for now you may run the command at any time to adjust its settings.\r\n\r\n' +
+          'To get started, you can assign the AutoHelper channels using the web interface linked below.\r\n' +
+          'You can adjust what commands users can see by adjusting your integration server settings.\r\n\r\n' +
           '*You may delete this message or click the buttons below for more info!*'
       );
       emb.setThumbnail('https://i.imgur.com/jxODw4N.png');
       const comps = new ActionRowBuilder<ButtonBuilder>();
+      comps.addComponents([new ButtonBuilder().setURL('https://www.pyrosfun.com/helper/dash').setLabel('Bot Dashboard').setStyle(ButtonStyle.Link)]);
       comps.addComponents([new ButtonBuilder().setURL('https://dsc.pyrosfun.com/').setLabel('Pyros Discord').setStyle(ButtonStyle.Link)]);
       comps.addComponents([new ButtonBuilder().setURL('https://www.pyrosfun.com/').setLabel('Pyros Website').setStyle(ButtonStyle.Link)]);
-      comps.addComponents([new ButtonBuilder().setURL('https://github.com/SuperPyroManiac/LSPDFR-Helper').setLabel('GitHub').setStyle(ButtonStyle.Link)]);
 
       if (!cachedServ) {
         cachedServ = new Server(server.id);

--- a/src/commands/Setup.ts
+++ b/src/commands/Setup.ts
@@ -27,11 +27,13 @@ export class SetupCommand extends Command {
           '__LSPDFR Helper Setup__\n-# Here is some info on your settings!\n\n' +
             '>>> **AutoHelper Channel:** This is the channel ID that the AutoHelper message will be posted in! To disable set it to 0\n\n' +
             '**Monitor Channel:** This is the channel ID that the AutoHelper monitor will be posted in. Set to 0 to disable! (The monitor shows all open cases!)\n\n' +
+            'Alternatively there is now a bot dashboard which should be used instead!\n\n' +
             `__**Your Current Settings:**__\n**AutoHelper Channel ID:** ${serv?.ahChId}\n**Monitor Channel ID:** ${serv?.ahMonChId}\n\n-# Click the button below to change these!`
         ),
       ],
       components: [
         new ActionRowBuilder<ButtonBuilder>().addComponents([
+          new ButtonBuilder().setURL('https://www.pyrosfun.com/helper/dash').setLabel('Bot Dashboard').setStyle(ButtonStyle.Link),
           new ButtonBuilder().setCustomId(SetupButton).setLabel('Change Settings').setStyle(ButtonStyle.Success),
         ]),
       ],


### PR DESCRIPTION
- In ServerValidation, update the welcome message to direct users to the bot dashboard for channel configuration
- In SetupCommand, add a link to the bot dashboard and remove the instructions for using the /Setup command
- This promotes the use of the web-based dashboard for managing the bot's settings