### PR TITLE
fix: update error update operation to use explicit field mapping

### DIFF
--- a/src/Functions/DBManager.ts
+++ b/src/Functions/DBManager.ts
@@ -108,7 +108,13 @@ export class DBManager {
     await this.handleDbOperation(async () => {
       await prisma.errors.update({
         where: { id: error.id },
-        data: error,
+        data: {
+          pattern: error.pattern,
+          solution: error.solution,
+          description: error.description,
+          stringMatch: error.stringMatch,
+          level: error.level,
+        },
       });
     });
     Cache.updateErrors((await this.getErrors()) ?? []);


### PR DESCRIPTION
Updates the error update operation in DBManager to use explicit field mapping instead of passing the entire error object:

- Replaces direct error object assignment with specific field mapping
- Explicitly maps pattern, solution, description, stringMatch, and level fields
- Prevents potential issues with unwanted field updates
- Maintains data integrity by controlling exactly which fields can be updated

This change improves data safety and makes the update operation more predictable.