### PR TITLE
Develop

### DIFF
--- a/src/Functions/AutoHelper/AhChannel.ts
+++ b/src/Functions/AutoHelper/AhChannel.ts
@@ -86,8 +86,8 @@ export class AhChannel {
     try {
       this.throttle(serverId, async () => {
         const description =
-          '\n-# You can check files for common issues here.\n-# Simply upload a file here to check it.\n\n' +
-          `${process.env['QUESTION']!} **__Currently supported files:__**\n> - **RagePluginHook Logs, ELS Logs, ASI Logs**\n> - **.xml Files, .meta Files, and Images**` +
+          '\nYou can check files for common issues here.\n**Simply upload a file here to check it.**\n\n' +
+          `${process.env['QUESTION']!} **__Currently supported files:__**\n> - RagePluginHook Logs, ELS Logs, ASI Logs\n> - .xml Files, .meta Files, and Images` +
           `\n\n${process.env['ALERT']!} **__AutoHelper Rules__**` +
           '\n> - No modified logs' +
           '\n> - No files bigger than **__5MB__**.' +

--- a/src/Web/SiteConnect/Servers/EditServer.ts
+++ b/src/Web/SiteConnect/Servers/EditServer.ts
@@ -44,8 +44,8 @@ export class EditServer {
         if (oldServer.request !== serverData.request) {
           changes.push(`**Request:** ${oldServer.request} → ${serverData.request}`);
         }
-        if (oldServer.ahType !== serverData.AhType) {
-          changes.push(`**AH Type:** ${oldServer.ahType} → ${serverData.AhType}`);
+        if (oldServer.ahType !== serverData.ahType) {
+          changes.push(`**AH Type:** ${oldServer.ahType} → ${serverData.ahType}`);
         }
         if (oldServer.ahChId !== serverData.ahChId) {
           changes.push(`**Helper Channel:** ${oldServer.ahChId} → ${serverData.ahChId}`);
@@ -61,7 +61,7 @@ export class EditServer {
         oldServer.banned = serverData.banned;
         oldServer.redirect = serverData.redirect;
         oldServer.request = serverData.request;
-        oldServer.ahType = serverData.AhType;
+        oldServer.ahType = serverData.ahType;
         oldServer.ahChId = serverData.ahChId;
         oldServer.ahMonChId = serverData.ahMonChId;
         oldServer.announceChId = serverData.announceChId;


### PR DESCRIPTION
Simplifies the formatting of AutoHelper channel description:

- Removes markdown list indicators (-#) for cleaner appearance
- Reduces excessive bold formatting in file type listings
- Maintains clear section headers and important warnings
- Preserves all existing content and file type information
- Keeps consistent spacing and structure

These changes improve readability while maintaining all essential information in the channel description.