### PR TITLE
fix: ignore ephemeral messages in AutoHelper channels

### DIFF
--- a/src/listeners/MessageCreate.ts
+++ b/src/listeners/MessageCreate.ts
@@ -60,7 +60,7 @@ export class MessageCreateListener extends Listener {
   }
 
   private async ahChannels(msg: Message) {
-    if (msg.embeds[0]?.description?.includes('Created by: SuperPyroManiac')) return;
+    if (msg.embeds[0]?.description?.includes('Created by: SuperPyroManiac') || msg.flags.has('Ephemeral')) return;
     if (Cache.getServer(msg.guildId!)?.ahType !== AhType.TICKET) {
       await this.ProcessMessage(msg);
       await AhChannel.UpdateChannelMsg(msg.guildId!);


### PR DESCRIPTION
Adds ephemeral message filtering to AutoHelper channel processing:

- Adds check for message.flags.has('Ephemeral') condition
- Prevents processing of ephemeral messages in AutoHelper channels
- Maintains existing SuperPyroManiac attribution check
- Preserves normal message processing flow

This change prevents AutoHelper from processing temporary ephemeral messages that shouldn't trigger updates.